### PR TITLE
Make sure OpenSSL also uses the voms verification time.

### DIFF
--- a/src/api/ccapi/api_util.cc
+++ b/src/api/ccapi/api_util.cc
@@ -736,9 +736,16 @@ vomsdata::check_cert(STACK_OF(X509) *stack)
 
         ERR_clear_error();
         error = VERR_VERIFY;
-        X509_STORE_CTX_init(csc, ctx, sk_X509_value(stack, 0), NULL);
-        X509_STORE_CTX_set_ex_data(csc, PVD_STORE_EX_DATA_IDX, pvd);
-        index = X509_verify_cert(csc);
+        if (X509_STORE_CTX_init(csc, ctx, sk_X509_value(stack, 0), NULL)==0) {
+	    error = VERR_MEM;
+	} else	{
+	    X509_STORE_CTX_set_ex_data(csc, PVD_STORE_EX_DATA_IDX, pvd);
+	    /* X509_STORE_CTX_get0_param() only returns NULL if
+	     * X509_STORE_CTX_init() has failed  */
+	    X509_VERIFY_PARAM_set_time(X509_STORE_CTX_get0_param(csc),
+				       verificationtime);
+	    index = X509_verify_cert(csc);
+	}
       }
     }
 #ifdef SIGPIPE


### PR DESCRIPTION
VOMS has an API call to set the verification time, VOMS_SetVerificationTime(),
to set the time at which an AC should be valid. However, the certificate(chain)
used to sign the AC (i.e. the VOMS server certificate and chain) is checked
using OpenSSLs X509_verify_cert() which checks it at the current time. The
logical time to check that chain would be the same time as used for the AC
itself. In order to do that, we call the OpenSSL X509_VERIFY_PARAM_set_time().
