### PR TITLE
Don't use SSLv3 method

### DIFF
--- a/src/socklib/Client.cpp
+++ b/src/socklib/Client.cpp
@@ -245,7 +245,7 @@ GSISocketClient::Open()
   char portstring[36];
   std::string error;
 
-  meth = SSLv3_method();
+  meth = SSLv23_method();
 
   ctx = SSL_CTX_new(meth);
 

--- a/testsuite/voms/voms/server.c
+++ b/testsuite/voms/voms/server.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
   SSL_library_init();
 
 
-  m_sslCtx = SSL_CTX_new( SSLv3_method() );
+  m_sslCtx = SSL_CTX_new( SSLv23_method() );
   if (!m_sslCtx) {
     ERR_print_errors_fp( stdout );
     printf("error1\n");

--- a/testsuite/voms/voms/server2.c
+++ b/testsuite/voms/voms/server2.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
   SSL_library_init();
 
 
-  m_sslCtx = SSL_CTX_new( SSLv3_method() );
+  m_sslCtx = SSL_CTX_new( SSLv23_method() );
   if (!m_sslCtx) {
     ERR_print_errors_fp( stdout );
     printf("error1\n");


### PR DESCRIPTION
The new version of openssl in Debian has been compiled without ssl3 support. This means that the SSLv3_method function no longer is available. For this reason the compilation of canl-c fails:

https://buildd.debian.org/status/package.php?p=voms

error: 'SSLv3_method' was not declared in this scope

I don't know what is the best way to fix this. One way is to use SSLv23_method instead, as in this pull request.

But you might have other ideas.
