### PR TITLE
Don't use macros in AC_CHECK_LIB

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -117,7 +117,7 @@ AC_DEFUN([AC_OPENSSL],
               [with_openssl_prefix=/usr])
 
   if test "x$with_openssl_prefix" = "x/usr" ; then
-    AC_CHECK_LIB(crypto, CRYPTO_num_locks, [found=yes], [found=no])
+    AC_CHECK_LIB(crypto, ERR_print_errors_fp, [found=yes], [found=no])
 
     if test "x$found" = "xyes" ; then
 	OPENSSL_LIBS="-lcrypto -lssl"
@@ -128,7 +128,7 @@ AC_DEFUN([AC_OPENSSL],
     LD_LIBRARY_PATH="$with_openssl_prefix/lib"
 
     AC_LANG_PUSH(C)
-    AC_CHECK_LIB(crypto, CRYPTO_num_locks, [found=yes], [found=no])
+    AC_CHECK_LIB(crypto, ERR_print_errors_fp, [found=yes], [found=no])
     AC_LANG_POP(C)  
     NO_GLOBUS_FLAGS="-I$with_openssl_prefix/include"
 


### PR DESCRIPTION
This is not the most important change since the configure script now uses pkg-config and not AC_OPENSSL. I noticed this when I was compiling an older git snapshot that still used AC_OPENSSL, and I report it in case you would want to go back to use AC_OPENSSL sometime in the future.

In OpenSSL 1.1 CRYPTO_num_locks is a preprocessor macro defined in the openssl headers, and there no longer is a function with this name in the crypto library:

    #  define CRYPTO_num_locks()            (1)

AC_CHECK_LIB only works with proper functions that exist in the library and fails if a preprocessor macro is used in the test.
