### PR TITLE
fix issue #54

### DIFF
--- a/src/ac/init.c
+++ b/src/ac/init.c
@@ -26,7 +26,17 @@
 
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
+#include <assert.h>
 #include "extensions.h"
+
+static void OBJC(char const* oid, char const* name)
+{
+  assert(oid != NULL && name != NULL);
+  if (OBJ_txt2nid(oid) == NID_undef) {
+    int nid = OBJ_create(oid, name, name);
+    assert(nid != NID_undef && "OBJ_create failed");
+  }
+}
 
 void declareOIDs(void)
 {
@@ -59,11 +69,10 @@ void declareOIDs(void)
 #define certseq               "1.3.6.1.4.1.8005.100.100.10"
 #define email                 idpkcs9 ".1"
 
-#define OBJC(c,n) OBJ_create(c,n,#c)
-
   static int done=0;
-  if (done)
+  if (done) {
     return;
+  }
 
   done=1;
 

--- a/src/sslutils/proxy.c
+++ b/src/sslutils/proxy.c
@@ -463,8 +463,9 @@ struct VOMSProxy *VOMS_MakeProxy(struct VOMSProxyArguments *args, int *warning, 
       policylang = LIMITED_PROXY_OID;
     }
 
-    if (OBJ_txt2nid(policylang) == 0) {
-      OBJ_create(policylang, policylang, policylang);
+    if (OBJ_txt2nid(policylang) == NID_undef) {
+      int nid = OBJ_create(policylang, policylang, policylang);
+      assert(nid != NID_undef && "OBJ_create failed");
     }
 
     if (!(policy_language = OBJ_txt2obj(policylang, 1))) {

--- a/src/sslutils/proxycertinfo.c
+++ b/src/sslutils/proxycertinfo.c
@@ -338,22 +338,19 @@ PROXY_CERT_INFO_EXTENSION_get_policy(PROXY_CERT_INFO_EXTENSION const* pci)
 
 void InitProxyCertInfoExtension(int full)
 {
-  static int init_done = 0;
+  if (OBJ_txt2nid(PROXYCERTINFO_OLD_OID) == NID_undef) {
+    int ret = 0;
+    X509V3_EXT_METHOD* meth = NULL;
 
-  if (init_done) {
-    return;
-  }
+    char const* pci_v3_sn =  "proxyCertInfo_V3";
+    char const* pci_v3_ln =  "Proxy Certificate Information (V3)";
+    int const v3nid = OBJ_create(PROXYCERTINFO_OLD_OID, pci_v3_sn, pci_v3_ln);
+    assert(v3nid != NID_undef && "OBJ_create failed");
 
-  char const* pci_v3_sn =  "proxyCertInfo_V3";
-  char const* pci_v3_ln =  "Proxy Certificate Information (V3)";
-  int const v3nid = OBJ_create(PROXYCERTINFO_OLD_OID, pci_v3_sn, pci_v3_ln);
-  assert(v3nid != 0 && "OBJ_create failed");
-
-  if (X509V3_EXT_get_nid(v3nid) == NULL) {
-    X509V3_EXT_METHOD* meth = PROXYCERTINFO_OLD_x509v3_ext_meth();
+    meth = PROXYCERTINFO_OLD_x509v3_ext_meth();
+    assert(meth != NULL && "PROXYCERTINFO_OLD_x509v3_ext_meth failed");
     meth->ext_nid = v3nid;
-    X509V3_EXT_add(meth);
+    ret = X509V3_EXT_add(meth);
+    assert(ret != 0 && "X509V3_EXT_add failed");
   }
-
-  init_done = 1;
 }

--- a/src/sslutils/sslutils.c
+++ b/src/sslutils/sslutils.c
@@ -472,12 +472,26 @@ ERR_load_prxyerr_strings(
             SSL_load_error_strings();
         }
 
-        OBJ_create("1.3.6.1.4.1.3536.1.1.1.1","CLASSADD","ClassAdd");
-        OBJ_create("1.3.6.1.4.1.3536.1.1.1.2","DELEGATE","Delegate");
-        OBJ_create("1.3.6.1.4.1.3536.1.1.1.3","RESTRICTEDRIGHTS",
-                   "RestrictedRights");
-        /* the following is already available in OpenSSL... */
-        OBJ_create("0.9.2342.19200300.100.1.1","USERID","userId");
+        if (OBJ_txt2nid("1.3.6.1.4.1.3536.1.1.1.1") == NID_undef) {
+          int nid = OBJ_create("1.3.6.1.4.1.3536.1.1.1.1","CLASSADD","ClassAdd");
+          assert(nid != NID_undef && "OBJ_create failed");
+        }
+
+        if (OBJ_txt2nid("1.3.6.1.4.1.3536.1.1.1.2") == NID_undef) {
+          int nid = OBJ_create("1.3.6.1.4.1.3536.1.1.1.2","DELEGATE","Delegate");
+          assert(nid != NID_undef && "OBJ_create failed");
+        }
+
+        if (OBJ_txt2nid("1.3.6.1.4.1.3536.1.1.1.3") == NID_undef) {
+          int nid = OBJ_create("1.3.6.1.4.1.3536.1.1.1.3","RESTRICTEDRIGHTS",
+                               "RestrictedRights");
+          assert(nid != NID_undef && "OBJ_create failed");
+        }
+
+        if (OBJ_txt2nid("0.9.2342.19200300.100.1.1") == NID_undef) {
+          int nid = OBJ_create("0.9.2342.19200300.100.1.1","USERID","userId");
+          assert(nid != NID_undef && "OBJ_create failed");
+        }
 
         ERR_load_strings(ERR_USER_LIB_PRXYERR_NUMBER,prxyerr_str_functs);
         ERR_load_strings(ERR_USER_LIB_PRXYERR_NUMBER,prxyerr_str_reasons);


### PR DESCRIPTION
This commit checks that all the calls to `OBJ_create` (directly or through the macro `OBJC`) are protected by a call to `OBJ_txt2nid` to see if the object already exists. The macro `OBJC` has been replaced by a proper function.
