### PR TITLE
Change default proxy cert key length to 2048 bits

### DIFF
--- a/src/client/vomsclient.cc
+++ b/src/client/vomsclient.cc
@@ -483,7 +483,7 @@ Client::Client(int argc, char ** argv) :
   /* controls that number of bits for the key is appropiate */
   
   if (bits == -1)
-    bits = 1024;
+    bits = 2048;
 
   if ((bits != 0) && (bits!=512) && (bits!=1024) && (bits!=2048) && (bits!=4096)) {
     Print(ERROR) << "Error: number of bits in key must be one of 512, 1024, 2048, 4096." << std::endl;

--- a/src/utils/vomsfake.cc
+++ b/src/utils/vomsfake.cc
@@ -219,7 +219,7 @@ Fake::Fake(int argc, char ** argv) :   confile(conf_file_name),
     "    -pwstdin                       Allows passphrase from stdin\n" \
     "    -limited                       Creates a limited proxy\n" \
     "    -hours H                       Proxy is valid for H hours (default:12)\n" \
-    "    -bits                          Number of bits in key {512|1024|2048|4096} (default:1024)\n" \
+    "    -bits                          Number of bits in key {512|1024|2048|4096} (default:2048)\n" \
     "    -cert     <certfile>           Non-standard location of user certificate\n" \
     "    -key      <keyfile>            Non-standard location of user key\n" \
     "    -certdir  <certdir>            Non-standard location of trusted cert dir\n" \
@@ -1021,7 +1021,7 @@ bool Fake::VerifyOptions()
   /* controls that number of bits for the key is appropiate */
 
   if (bits == -1)
-    bits = 1024;
+    bits = 2048;
 
   if ((bits!=512) && (bits!=1024) && 
       (bits!=2048) && (bits!=4096) && (bits != 0))

--- a/testsuite/lib/vomslib.exp
+++ b/testsuite/lib/vomslib.exp
@@ -308,7 +308,7 @@ commonName		= supplied
 emailAddress		= optional
 
 \[req\]
-default_bits		= 1024
+default_bits		= 2048
 default_keyfile 	= privkey.pem
 distinguished_name=req_distinguished_name
 #attributes		= req_attributes

--- a/testsuite/voms/voms/voms007.exp
+++ b/testsuite/voms/voms/voms007.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms009.exp
+++ b/testsuite/voms/voms/voms009.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms010.exp
+++ b/testsuite/voms/voms/voms010.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms011.exp
+++ b/testsuite/voms/voms/voms011.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms014.exp
+++ b/testsuite/voms/voms/voms014.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \(\[0-9\]*\):\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms016.exp
+++ b/testsuite/voms/voms/voms016.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \(\[0-9\]*\):\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms020.exp
+++ b/testsuite/voms/voms/voms020.exp
@@ -29,7 +29,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms021.exp
+++ b/testsuite/voms/voms/voms021.exp
@@ -26,7 +26,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms025.exp
+++ b/testsuite/voms/voms/voms025.exp
@@ -23,7 +23,7 @@ proc mytest {} {
         set correct "=== Proxy Chain Information ===
 subject   : /C=IT/CN=001
 issuer    : /C=IT/O=INFN/CN=CAFromthisCN
-strength  : 1024 bits
+strength  : 2048 bits
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 
 === Proxy Information ===
@@ -31,7 +31,7 @@ subject   : /C=IT/CN=001/CN=proxy
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms030.exp
+++ b/testsuite/voms/voms/voms030.exp
@@ -20,7 +20,7 @@ proc mytest {} {
         return $::FAILTEST
     } else {
         #match against known (correct) output
-        set correct "1024"
+        set correct "2048"
 
         loadvar out2 $outname
         if [regexp $correct $out2] then {

--- a/testsuite/voms/voms/voms041.exp
+++ b/testsuite/voms/voms/voms041.exp
@@ -24,7 +24,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \(\[0-9\]*\):\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms042.exp
+++ b/testsuite/voms/voms/voms042.exp
@@ -5,7 +5,7 @@ proc mytest {} {
     _activateCert mycert2
 
     _vomsStart voms1
-    set res [log_exec outname {voms-proxy-init --voms voms1 --bits 2048}]
+    set res [log_exec outname {voms-proxy-init --voms voms1 --bits 4096}]
     _vomsStop voms1
 
     if $res then {
@@ -24,7 +24,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 2048 bits
+strength  : 4096 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms043.exp
+++ b/testsuite/voms/voms/voms043.exp
@@ -30,7 +30,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 included  : testo di prova"

--- a/testsuite/voms/voms/voms044.exp
+++ b/testsuite/voms/voms/voms044.exp
@@ -24,13 +24,13 @@ proc mytest {} {
         set correct "=== Proxy Chain Information ===
 subject   : /C=IT/CN=001
 issuer    : /C=IT/O=INFN/CN=CAFromthisCN
-strength  : 1024 bits
+strength  : 2048 bits
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 
 subject   : /C=IT/CN=001/CN=proxy
 issuer    : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 
 === Proxy Information ===
@@ -38,7 +38,7 @@ subject   : /C=IT/CN=001/CN=proxy/CN=proxy
 issuer    : /C=IT/CN=001/CN=proxy
 identity  : /C=IT/CN=001/CN=proxy
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms059.exp
+++ b/testsuite/voms/voms/voms059.exp
@@ -24,7 +24,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms060.exp
+++ b/testsuite/voms/voms/voms060.exp
@@ -24,7 +24,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms061.exp
+++ b/testsuite/voms/voms/voms061.exp
@@ -24,13 +24,13 @@ proc mytest {} {
         set correct "=== Proxy Chain Information ===
 subject   : /C=IT/CN=001
 issuer    : /C=IT/O=INFN/CN=CAFromthisCN
-strength  : 1024 bits
+strength  : 2048 bits
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 
 subject   : /C=IT/CN=001/CN=proxy
 issuer    : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 
 === Proxy Information ===
@@ -38,7 +38,7 @@ subject   : /C=IT/CN=001/CN=proxy/CN=proxy
 issuer    : /C=IT/CN=001/CN=proxy
 identity  : /C=IT/CN=001/CN=proxy
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms091.exp
+++ b/testsuite/voms/voms/voms091.exp
@@ -43,7 +43,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms092.exp
+++ b/testsuite/voms/voms/voms092.exp
@@ -31,7 +31,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*
 key usage : Digital Signature, Key Encipherment

--- a/testsuite/voms/voms/voms124.exp
+++ b/testsuite/voms/voms/voms124.exp
@@ -18,7 +18,7 @@ proc mytest {} {
 
     set correct "Detected Globus version: 2.2
 Unspecified proxy version, settling on Globus version: 2
-Number of bits in key :1024
+Number of bits in key :2048
 Files being used:
  CA certificate file: none
  Trusted certificates directory : $::ETC_DIR/grid-security/certificates

--- a/testsuite/voms/voms/voms142.exp
+++ b/testsuite/voms/voms/voms142.exp
@@ -24,7 +24,7 @@ proc mytest {} {
 issuer    : /C=IT/CN=001
 identity  : /C=IT/CN=001
 type      : proxy
-strength  : 1024 bits
+strength  : 2048 bits
 path      : /tmp/x509up_u\[0-9\]*
 timeleft  : \[0-9\]*:\[0-9\]*:\[0-9\]*"
 

--- a/testsuite/voms/voms/voms143.exp
+++ b/testsuite/voms/voms/voms143.exp
@@ -21,7 +21,7 @@ proc mytest {} {
         return $::FAILTEST
     }
 
-    set correct "Key: \\(1024 bit\\)"
+    set correct "Key: \\(2048 bit\\)"
 
     loadvar out2 $outname
     if [regexp $correct $out2] then {


### PR DESCRIPTION
The updated openssl 1.1.1 in Debian has new default security settings and rejects certificates with RSA key size less than 2048 bits by default. voms-proxy-init generates proxies with a key size of 1024 bits by default. Trying to connect using these proxies from a Debian machine with openssl 1.1.1 fails. See e.g. the Debian BTS bug report https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911248.

This PR changes the default key size used by voms-proxy-init when generating proxies to 2048 bits.

The default key size used by grid-proxy-init has already been changed to 2048 bits (in both the old Globus Toolkit upstream and the new Grid Community Toolkit).
