### PR TITLE
Fix AC incompatibilty introduced with the migration to OpenSSL 1.1

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -22,3 +22,4 @@
 /utils/voms-proxy-fake
 /utils/voms-proxy-info
 /utils/voms-verify
+/client/voms-proxy-init

--- a/src/ac/extensions.c
+++ b/src/ac/extensions.c
@@ -233,46 +233,24 @@ int initEx(void)
 {
   X509V3_EXT_METHOD *targets;
   X509V3_EXT_METHOD *avail;
-  X509V3_EXT_METHOD *auth;
   X509V3_EXT_METHOD *acseq;
   X509V3_EXT_METHOD *certseq;
   X509V3_EXT_METHOD *attribs;
 
   avail   = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
   targets = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
-  auth    = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
   acseq   = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
   certseq = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
   attribs = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(X509V3_EXT_METHOD));
 
-  if (!avail || !targets || !auth || !acseq || !certseq || !attribs) {
+  if (!avail || !targets || !acseq || !certseq || !attribs) {
     OPENSSL_free(avail);
     OPENSSL_free(targets);
-    OPENSSL_free(auth);
     OPENSSL_free(acseq);
     OPENSSL_free(certseq);
     OPENSSL_free(attribs);
     return 0;
   }
-
-#ifndef VOMS_USE_OPENSSL_EXT_CODE
-  memset(auth, 0, sizeof(*auth));
-
-  auth->ext_nid  = OBJ_txt2nid("authorityKeyIdentifier");
-
-  auth->ext_flags = 0;
-  auth->ext_new  = (X509V3_EXT_NEW) AUTHORITY_KEYID_new;
-  auth->ext_free = (X509V3_EXT_FREE)AUTHORITY_KEYID_free;
-  auth->d2i      = (X509V3_EXT_D2I) d2i_AUTHORITY_KEYID;
-  auth->i2d      = (X509V3_EXT_I2D) i2d_AUTHORITY_KEYID;
-  auth->i2s      = (X509V3_EXT_I2S) authkey_i2s;
-  auth->s2i      = (X509V3_EXT_S2I) authkey_s2i;
-  auth->v2i      = (X509V3_EXT_V2I) NULL;
-  auth->r2i      = (X509V3_EXT_R2I) NULL;
-  auth->i2v      = (X509V3_EXT_I2V) NULL;
-  auth->i2r      = (X509V3_EXT_I2R) NULL;
-
-  X509V3_EXT_add(auth);
 
   memset(avail, 0, sizeof(*avail));
   avail->ext_nid  = OBJ_txt2nid("noRevAvail");
@@ -303,7 +281,6 @@ int initEx(void)
   targets->v2i      = (X509V3_EXT_V2I) NULL;
   targets->r2i      = (X509V3_EXT_R2I) NULL;
   targets->i2r      = (X509V3_EXT_I2R) NULL;
-#endif
 
   X509V3_EXT_add(targets);
 

--- a/src/ac/write.c
+++ b/src/ac/write.c
@@ -55,19 +55,13 @@ void add_no_rev_avail_ext(AC *ac) {
 
 int add_authority_key_id_ext(AC *ac, X509* issuer_cert) {
 
-  // Copy akid extension from issuer_cert
-  int ext_loc = X509_get_ext_by_NID(issuer_cert, NID_authority_key_identifier, -1);
-
-  if (ext_loc == -1){
-    return 1;
+  X509V3_CTX ctx;
+  X509V3_set_ctx(&ctx, issuer_cert, NULL, NULL, NULL, 0);
+  X509_EXTENSION* ext = X509V3_EXT_conf(NULL, &ctx, "authorityKeyIdentifier", "keyid:always");
+  if (!ext) {
+    return AC_ERR_NO_EXTENSION;
   }
-
-  X509_EXTENSION *akid = X509_get_ext(issuer_cert, ext_loc);
-
-  assert( akid != NULL );
-
-  X509v3_add_ext(&ac->acinfo->exts, akid, -1);
-
+  sk_X509_EXTENSION_push(ac->acinfo->exts, ext);
   return 0;
 }
 


### PR DESCRIPTION
See [here](https://issues.infn.it/jira/browse/VOMS-875?focusedCommentId=89355&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-89355) for an explanation.

This PR (tentatively) addresses the incompatibility, but not yet the storm frontend segfault.