### PR TITLE
config.h must not be included in public header file

### DIFF
--- a/src/api/ccapi/voms_api.h
+++ b/src/api/ccapi/voms_api.h
@@ -26,8 +26,6 @@
 #ifndef VOMS_API_H
 #define VOMS_API_H
 
-#include "config.h"
-
 #include <fstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
voms_api.h is the public header included by code that uses the voms library. It must not include the config.h header which is internal to the voms build.