### PR TITLE
Catch exception by reference

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -198,7 +198,7 @@ getopts(int argc, char * const argv[], struct option *longopts)
 
   try {
     opts = new struct option[num+1];
-  } catch ( std::bad_alloc) {
+  } catch (std::bad_alloc &e) {
     return false;
   }
   


### PR DESCRIPTION
~~~
options.cc: In function 'bool getopts(int, char* const*, option*)':
options.cc:201:18: warning: catching polymorphic type 'class std::bad_alloc' by\
 value [-Wcatch-value=]
  201 |   } catch ( std::bad_alloc) {
      |                  ^~~~~~~~~
~~~
