### PR TITLE
May be truncated

### DIFF
--- a/src/sslutils/evaluate.c
+++ b/src/sslutils/evaluate.c
@@ -353,8 +353,8 @@ void PRIVATE read_pathrestriction(STACK_OF(X509) *chain, char *path,
     hash = gethash(cert, hashed);
 
     /* Determine file names */
-    strncpy(signing + 1, hash, 8);
-    strncpy(namespace + 1, hash, 8);
+    memcpy(signing + 1, hash, 8);
+    memcpy(namespace + 1, hash, 8);
 
     file = open_from_dir(path, signing);
     if (file) {


### PR DESCRIPTION
~~~
evaluate.c: In function 'read_pathrestriction':
evaluate.c:356:5: warning: 'strncpy' output may be truncated copying 8 bytes from a string of length 8 [-Wstringop-truncation]
  356 |     strncpy(signing + 1, hash, 8);
      |     ^
evaluate.c:357:5: warning: 'strncpy' output may be truncated copying 8 bytes from a string of length 8 [-Wstringop-truncation]
  357 |     strncpy(namespace + 1, hash, 8);
      |     ^
~~~
