### PR TITLE
Add "lexparse.h" headers for lexer/parser integration

### DIFF
--- a/src/sslutils/lex.namespaces.c
+++ b/src/sslutils/lex.namespaces.c
@@ -1410,6 +1410,7 @@ static yyconst flex_int16_t yy_rule_linenum[15] =
 #include <stdlib.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "namespaces.h"
 #ifndef strndup
 extern char *strndup(const char*, size_t);

--- a/src/sslutils/lex.signing.c
+++ b/src/sslutils/lex.signing.c
@@ -2356,6 +2356,7 @@ static yyconst flex_int16_t yy_rule_linenum[17] =
 
 #include "parsertypes.h"
 #include "signing_policy.h"
+#include "lexparse.h"
 #ifndef strndup
 extern char *strndup(const char*, size_t);
 #endif

--- a/src/sslutils/lexparse.h
+++ b/src/sslutils/lexparse.h
@@ -1,0 +1,4 @@
+/* Declarations for lexer/parser integration. */
+union YYSTYPE;
+int signinglex (union YYSTYPE *, void *);
+int namespaceslex (union YYSTYPE *, void *);

--- a/src/sslutils/namespaces.c
+++ b/src/sslutils/namespaces.c
@@ -108,6 +108,7 @@
 #include <stdlib.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "listfunc.h"
 
 char **parse_subjects(char *string);

--- a/src/sslutils/namespaces.l
+++ b/src/sslutils/namespaces.l
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "namespaces.h"
 #ifndef strndup
 extern char *strndup(const char*, size_t);

--- a/src/sslutils/namespaces.y
+++ b/src/sslutils/namespaces.y
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "listfunc.h"
 
 char **parse_subjects(char *string);

--- a/src/sslutils/signing_policy.c
+++ b/src/sslutils/signing_policy.c
@@ -110,6 +110,7 @@
 #include <ctype.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "listfunc.h"
 
 char **parse_subjects(char *string);

--- a/src/sslutils/signing_policy.l
+++ b/src/sslutils/signing_policy.l
@@ -31,6 +31,7 @@
 
 #include "parsertypes.h"
 #include "signing_policy.h"
+#include "lexparse.h"
 #ifndef strndup
 extern char *strndup(const char*, size_t);
 #endif

--- a/src/sslutils/signing_policy.y
+++ b/src/sslutils/signing_policy.y
@@ -31,6 +31,7 @@
 #include <ctype.h>
 
 #include "parsertypes.h"
+#include "lexparse.h"
 #include "listfunc.h"
 
 char **parse_subjects(char *string);

--- a/src/utils/lex.yy.c
+++ b/src/utils/lex.yy.c
@@ -486,6 +486,7 @@ char *yytext;
 
 #include "fakeparsertypes.h"
 #include "vomsparser.h"
+#include "lexparse.h"
 
 #line 491 "lex.yy.c"
 

--- a/src/utils/lexparse.h
+++ b/src/utils/lexparse.h
@@ -1,0 +1,4 @@
+/* Declarations for lexer/parser integration. */
+union YYSTYPE;
+int yylex();
+void yyerror(const char *);

--- a/src/utils/vomsfake.y
+++ b/src/utils/vomsfake.y
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "fakeparsertypes.h"
+#include "lexparse.h"
 
 #define MAX_SIZE 200
 

--- a/src/utils/vomsparser.c
+++ b/src/utils/vomsparser.c
@@ -90,6 +90,7 @@
 #include <string.h>
 
 #include "fakeparsertypes.h"
+#include "lexparse.h"
 
 #define MAX_SIZE 200
 

--- a/src/utils/vomsparser.l
+++ b/src/utils/vomsparser.l
@@ -31,6 +31,7 @@
 
 #include "fakeparsertypes.h"
 #include "vomsparser.h"
+#include "lexparse.h"
 %}
 
 %x STR


### PR DESCRIPTION
And include them in a few strategic places.  This avoids build failures with future compilers that do not support implicit function declarations by default.

(NB: This commit does not regenerate the lexers/parsers, so the line numbers are slightly off.)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
