### PR TITLE
Only set authority key identified field if the public key is available

### DIFF
--- a/src/sslutils/proxy.c
+++ b/src/sslutils/proxy.c
@@ -389,12 +389,12 @@ struct VOMSProxy *VOMS_MakeProxy(struct VOMSProxyArguments *args, int *warning, 
       ex11 = X509V3_EXT_conf_nid(NULL, &ctx, NID_authority_key_identifier, "keyid");
     }
 
-    if (!ex11) {
+    if (ex11) {
+      if (!SET_EXT(ex11)) {
+        goto err;
+      }
+    } else if (args->selfsigned) {
       PRXYerr(PRXYERR_F_PROXY_SIGN,PRXYERR_R_CLASS_ADD_EXT);
-      goto err;
-    }
-          
-    if (!SET_EXT(ex11)) {
       goto err;
     }
   }


### PR DESCRIPTION
When using `voms-proxy-init` with a proxy certificate and OpenSSL 3 I get an error:

```bash
$ voms-proxy-init -out $PWD/test1
$ voms-proxy-init -cert $PWD/test1 -key $PWD/test1 -out $PWD/test2
Your proxy is valid until Tue Feb 14 00:52:34 2023
Error: verification failed.
Parameters unset!
```

If I use a `voms-proxy-init` binary that was compiled with OpenSSL 1.1.1 the above example works.

Looking deeper in to the problem I found that this line was failing with OpenSSL 3:

```c
ex11 = X509V3_EXT_conf_nid(NULL, &ctx, NID_authority_key_identifier, "keyid");
```

Inspecting the openssl error queue I found this message:

```
Error adding extension: error:1100007B:X509 V3 routines::unable to get issuer keyid
```

If I look at the certifictate that was generated with OpenSSL 1.1.1 I find the AKI is null so I presume OpenSSL 3 is being less permissive about this invalid state:

```bash
$ openssl crl2pkcs7 -nocrl -certfile test2 | openssl pkcs7 -print_certs -text -noout | grep -A 4 'Authority Key Identifier'
            X509v3 Authority Key Identifier:
                0.
            Proxy Certificate Information: critical
                Path Length Constraint: infinite
                Policy Language: Inherit all
```

I think the right thing to do in this case is to just not add the AKI extension.