### PR TITLE
If a detailed error message is available, do not overwrite

### DIFF
--- a/src/api/ccapi/api_util.cc
+++ b/src/api/ccapi/api_util.cc
@@ -327,7 +327,12 @@ vomsdata::verifydata(AC *ac, UNUSED(const std::string& subject),
     issuer = check((void *)ac);
 
     if (!issuer) {
-      seterror(VERR_SIGN, "Cannot verify AC signature!");
+      std::string oldmessage = ErrorMessage();
+      if (oldmessage.empty()) {
+          seterror(VERR_SIGN, "Cannot verify AC signature!");
+      } else {
+          seterror(VERR_SIGN, "Cannot verify AC signature!  Underlying error: " + oldmessage);
+      }
       return false;
     }
   }


### PR DESCRIPTION
When verification of ACs fails, the prior behavior is to always have this message:

```
Cannot verify AC signature!
```

This can be difficult to debug as there's no indication of whether its a problem with the proxy itself or with the host configuration.

This patch appends the underlying error message if one was provided. For example,

```
Cannot verify AC signature!  Underlying error: Certificate verification \
  failed for certificate '/CN=voms.example.com': certificate has expired.
```

(newlines added for readability)