### PR TITLE
Allow authority key identifier to be NULL, as seen on EL9 with CILogon client cert

### DIFF
--- a/src/sslutils/proxy.c
+++ b/src/sslutils/proxy.c
@@ -366,13 +366,10 @@ struct VOMSProxy *VOMS_MakeProxy(struct VOMSProxyArguments *args, int *warning, 
       ex11 = X509V3_EXT_conf_nid(NULL, &ctx, NID_authority_key_identifier, "keyid");
     }
 
-    if (!ex11) {
-      PRXYerr(PRXYERR_F_PROXY_SIGN,PRXYERR_R_CLASS_ADD_EXT);
-      goto err;
+    if (ex11) {
+      if (!SET_EXT(ex11))
+        goto err;
     }
-          
-    if (!SET_EXT(ex11))
-      goto err;
   }
 
   /* class_add extension */


### PR DESCRIPTION
CILogon client certificates do not have an X509v3 extension called `X509v3 Authority Key Identifier`.  On EL7 (at least) when looking up that identifier the result is a structure with a `-1` error indicator in it, but on EL9 (at least) the result is just NULL.  This currently causes voms-proxy-init to exit (without a helpful error message even in `-debug` mode, by the way).  So silently ignore that condition instead of returning an error.