### PR TITLE
Only process authority & subject key identifiers in certs

### DIFF
--- a/src/sslutils/proxy.c
+++ b/src/sslutils/proxy.c
@@ -330,9 +330,10 @@ struct VOMSProxy *VOMS_MakeProxy(struct VOMSProxyArguments *args, int *warning, 
       goto err;
   }
   
-  /* authority key identifier and subject key identifier extension */
+  /* authority key identifier and subject key identifier extension
+     (certificates only, not proxies) */
 
-  {
+  if (args->proxyversion == 0) {
     X509V3_CTX ctx;
     
     X509V3_set_ctx(&ctx, (args->selfsigned ? NULL : args->cert), NULL, req, NULL, 0);


### PR DESCRIPTION
This changes the processing of authority key identifier and subject key identifier extensions to only be done on certificates, not proxies.  This is an alternative fix to the problem identified in #113 (although the fix there turned out to also be needed for a different problem, certificates without an authority key identifier).