### PR TITLE
Fix problem with newer gsoap versions.

### DIFF
--- a/src/server/vomsd.cc
+++ b/src/server/vomsd.cc
@@ -841,7 +841,12 @@ void VOMSServer::Run()
             sop->ssl = sock.ssl;
 
             // GSOAP will handle this
-            sop->fparse(sop);
+            // newer versions of gsoap don't call the http handlers (eg fget) in fparse
+            // fparse returns SOAP_STOP if any of the handlers were called instead of SOAP_OK (older versions)
+            // if the return value is SOAP_OK then no hander has been called (newer versions) and we call
+            // fget manually if it's a get request (SOAP_GET)
+            if(sop->fparse(sop) == SOAP_OK && sop->status == SOAP_GET)
+              sop->fget(sop);
 
             sock.Close();
           } else {


### PR DESCRIPTION
The version of gsoap that comes with Rocky 9 does not call the request handlers in fparse.
The http_get handler never gets called on the server.
This causes clients to fail that use the REST API (voms-proxy-init3) as the server just terminates the connection without returning anything.

This is a quick patch that solves this by calling the http_get handler if fparse didn't.
This has only been tested on Rocky 9, but should also work on EL7/8 systems.
