### PR TITLE
Fix lintian warning

### DIFF
--- a/src/install/voms_install_db.in
+++ b/src/install/voms_install_db.in
@@ -273,7 +273,7 @@ $ECHO $voms_password_query > $datapath/voms/$voms_vo/voms.pass
 
 uid=`/usr/bin/id -u`
 
-[ $uid = "0" ] && chown root.voms $datapath/voms/$voms_vo/voms.pass 
+[ $uid = "0" ] && chown root:voms $datapath/voms/$voms_vo/voms.pass
 chmod 640 $datapath/voms/$voms_vo/voms.pass
 
 if test -z $voms_vo ; then


### PR DESCRIPTION
voms-server: chown-with-dot root.voms [usr/share/voms/voms_install_db:276]

chown-with-dot

  The named script uses a dot to separate owner and group in a call like
  chown user.group but that usage is deprecated.

  Please use a colon instead, as in:

  chown user:group.