### PR TITLE
Avoid function names when printing OpenSSL errors

### DIFF
--- a/src/client/vomsclient.cc
+++ b/src/client/vomsclient.cc
@@ -1049,7 +1049,7 @@ bool Client::Test()
     Print(WARN) << std::endl << "ERROR: Your certificate expired "
                 << asctime(localtime(&time_after)) << std::endl;
     
-    return 2;
+    return true;
   } 
   
   if (hours && time_diff < length) {
@@ -1057,7 +1057,7 @@ bool Client::Test()
                 << asctime(localtime(&time_after))
                 << "which is within the requested lifetime of the proxy"
                 << std::endl;
-    return 1;
+    return false;
   }
   
   if (!quiet) {
@@ -1068,7 +1068,7 @@ bool Client::Test()
                 << asctime(localtime(&time_after_proxy)) << std::flush;
   }
 
-  return 0;
+  return false;
 }
 
 bool Client::AddToList(AC *ac) 

--- a/src/common/data.cc
+++ b/src/common/data.cc
@@ -157,8 +157,8 @@ std::string OpenSSLError(bool debug)
     std::size_t const buf_size = 256;
     char buf[buf_size];
     ERR_error_string_n(code, buf, buf_size);
-    os << buf << ':' << file << ':'
-       << line << ':' << (data && (flags & ERR_TXT_STRING) ? data : "") << '\n';
+    os << file << ':' << line << ':'
+       << buf << (data && (flags & ERR_TXT_STRING) ? data : "") << '\n';
     code = ERR_get_error_line_data(&file, &line, &data, &flags);
   }
 

--- a/src/socklib/Server.cpp
+++ b/src/socklib/Server.cpp
@@ -719,7 +719,8 @@ void GSISocketServer::SetErrorOpenSSL(const std::string &err)
 
   while( ERR_peek_error() ){
 
-    char error_msg_buf[512];
+    std::size_t const error_msg_buf_size = 512;
+    char error_msg_buf[error_msg_buf_size];
 
     const char *filename;
     int lineno;
@@ -729,7 +730,6 @@ void GSISocketServer::SetErrorOpenSSL(const std::string &err)
     long error_code = ERR_get_error_line_data(&filename, &lineno, &data, &flags);
 
     const char *lib = ERR_lib_error_string(error_code);
-    const char *func = ERR_func_error_string(error_code);
     const char *error_reason = ERR_reason_error_string(error_code);
 
     if (lib == NULL) {
@@ -741,11 +741,11 @@ void GSISocketServer::SetErrorOpenSSL(const std::string &err)
       }
     }
 
-    sprintf(error_msg_buf,
-        "%s %s [err:%lu,lib:%s,func:%s(file: %s+%d)]",
+    snprintf(error_msg_buf, error_msg_buf_size,
+        "%s %s [err:%lu,lib:%s,file:%s+%d]",
         (error_reason) ? error_reason : "",
-        (data) ? data : "",
-        error_code,lib,func,filename,lineno);
+        (data && (flags & ERR_TXT_STRING)) ? data : "",
+        error_code,lib,filename,lineno);
 
     openssl_errors.push_back(error_msg_buf);
   }

--- a/src/sslutils/sslutils.c
+++ b/src/sslutils/sslutils.c
@@ -519,7 +519,7 @@ ERR_load_prxyerr_strings(
 
         randfile = RAND_file_name(buffer,200);
 
-        if (randfile && access(randfile, "r") == 0)
+        if (randfile && access(randfile, R_OK) == 0)
         {
             RAND_load_file(randfile,1024L*1024L);
         }

--- a/testsuite/voms/voms/server.c
+++ b/testsuite/voms/voms/server.c
@@ -164,11 +164,8 @@ int main(int argc, char *argv[])
         //      if (debug)
         fprintf(stdout, "%s:%s,%d,%s\n", ERR_error_string(l, buf),
                 file, line, dat);
-        //      error += std::string(ERR_reason_error_string(l)) + ":" + std::string(ERR_func_error_string(l)) + "\n";
       }
     }
-/*     fprintf(stdout, "%s\n", */
-/*             ERR_reason_error_string( ERR_get_error() )); */
     fprintf(stdout, "ERROR\n");
     exit(1);
   }

--- a/testsuite/voms/voms/server2.c
+++ b/testsuite/voms/voms/server2.c
@@ -161,11 +161,8 @@ int main(int argc, char *argv[])
         //      if (debug)
         fprintf(stdout, "%s:%s,%d,%s\n", ERR_error_string(l, buf),
                 file, line, dat);
-        //      error += std::string(ERR_reason_error_string(l)) + ":" + std::string(ERR_func_error_string(l)) + "\n";
       }
     }
-/*     fprintf(stdout, "%s\n", */
-/*             ERR_reason_error_string( ERR_get_error() )); */
     fprintf(stdout, "ERROR\n");
     exit(1);
   }


### PR DESCRIPTION
With OpenSSL 3, function names are not included any more in SSL errors; trying to print them is then meaningless.
This PR mainly changes how the error message obtained from the queue of SSL errors is produced, relying on the canonical loop over the queue and avoiding function names.

Partially addresses #110. More work is needed to correctly register VOMS-specific errors, which doesn't seem quite right even in the current implementation.