### PR TITLE
Make the build more robust against non-standard installations of some dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,6 @@ on:
   push:
 
 jobs:
-  
-  centos7:
-    runs-on: ubuntu-latest
-    container: centos:centos7
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install packages
-        run: |
-          yum install -y epel-release
-          yum install -y make file automake libtool gcc-c++ openssl-devel gsoap-devel gsoap expat-devel bison
-
-      - name: Build
-        run: |
-          ./autogen.sh
-          ./configure
-          make
 
   el9:
     runs-on: ubuntu-latest
@@ -48,10 +31,27 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update
-          sudo apt install make automake libtool pkg-config g++ libssl-dev libgsoap-dev gsoap libexpat-dev
+          sudo apt install -y make automake libtool pkg-config g++ libssl-dev libgsoap-dev gsoap libexpat-dev
 
       - name: Build
         run: |
           ./autogen.sh
           ./configure
           make
+
+  ubuntu2404:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install -y make automake libtool pkg-config g++ libssl-dev libgsoap-dev gsoap libexpat-dev
+
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+

--- a/configure.ac
+++ b/configure.ac
@@ -34,19 +34,7 @@ AC_COMPILER
 AX_PTHREAD
 
 PKG_CHECK_MODULES([OPENSSL], [openssl], [AC_DEFINE([OPENSSL_API_COMPAT], [10100], [Build against OpenSSL 1.1 API])])
-
-AC_CHECK_HEADER([expat.h], 
-    [], 
-    [AC_MSG_ERROR("Could not find expat.h. Please install the expat development package.")],
-    [])
-
-AC_CHECK_LIB([expat],
-    [XML_ParserCreate],
-    [EXPAT_LIBS=-lexpat],
-    [AC_MSG_ERROR("Error checking libexpat. Please install the expat development package.")]
-    )
-
-AC_SUBST(EXPAT_LIBS)
+PKG_CHECK_MODULES([EXPAT],[expat])
 
 AC_ENABLE_DOCS
 

--- a/m4/wsdl2h.m4
+++ b/m4/wsdl2h.m4
@@ -20,10 +20,6 @@ AC_DEFUN([AC_WSDL2H],
         	[with_gsoap_wsdl2h="$withval"],
         	[with_gsoap_wsdl2h="/usr/bin/wsdl2h"])
 	
-	dnl SOAPCPP flags in addition to what is already set by gsoap
-	SOAPCPP2="/usr/bin/soapcpp2"
-	AC_SUBST(SOAPCPP2)
-	
 	dnl wsdl2h macros. we try to udnerstand which flags need to be used depending
 	dnl on wsdl2h version
 	AC_MSG_CHECKING([wsdl2h version])
@@ -65,4 +61,17 @@ AC_DEFUN([AC_WSDL2H],
 	AC_MSG_RESULT([yes. wsdl2h version $wsdl2h_version detected.])
 	AC_SUBST(WSDL2H)
 	AC_SUBST(WSDL2H_FLAGS)
+
+	WSDL2H_DIR=$(AS_DIRNAME([$WSDL2H]))
+	SOAPCPP2=$WSDL2H_DIR/soapcpp2
+
+	if ! test -e "$SOAPCPP2"; then
+		AC_MSG_ERROR("soapcpp2 executable: $SOAPCPP2 does not exist.")
+	fi
+
+	if ! test -x "$SOAPCPP2"; then
+		AC_MSG_ERROR("soapcpp2 executable: $SOAPCPP2 cannot be executed.")
+	fi
+	
+    AC_SUBST([SOAPCPP2])
 ])

--- a/src/ac/Makefile.am
+++ b/src/ac/Makefile.am
@@ -1,3 +1,7 @@
+AM_CPPFLAGS= \
+	-I $(top_srcdir)/src/include \
+	-I $(top_srcdir)/src/sslutils \
+	$(OPENSSL_CFLAGS)
 
 noinst_LTLIBRARIES = \
   libattributes_nog.la
@@ -17,21 +21,13 @@ libattributes_nog_la_SOURCES = $(AC_C_SOURCES) $(AC_CC_SOURCES)
 
 libattributes_nog_la_CFLAGS = \
 	$(NO_GLOBUS_FLAGS) \
-	-DNOGLOBUS \
-	-I $(top_srcdir)/src/include \
-	-I $(top_builddir)/src/sslutils
+	-DNOGLOBUS
 
 libattributes_nog_la_CXXFLAGS = \
 	$(NO_GLOBUS_FLAGS) \
-	-DNOGLOBUS \
-	-I $(top_srcdir)/src/include \
-	-I $(top_builddir)/src/sslutils
+	-DNOGLOBUS
 
 libattributes_nog_la_LIBADD = \
 	$(OPENSSL_LIBS)
-
-AM_CPPFLAGS= \
-	-I $(top_srcdir)/src/include \
-	-I $(top_srcdir)/src/sslutils
 
 ###

--- a/src/api/ccapi/Makefile.am
+++ b/src/api/ccapi/Makefile.am
@@ -19,7 +19,8 @@ libvomsapi_la_CXXFLAGS = \
 	$(PTHREAD_CFLAGS) \
 	$(NO_GLOBUS_FLAGS) \
 	-DNOGLOBUS \
-	-I$(top_srcdir)/src/include
+	-I$(top_srcdir)/src/include \
+	$(OPENSSL_CFLAGS)
 
 libvomsapi_la_LDFLAGS = \
 	-rpath $(libdir) \

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -1,3 +1,11 @@
+AM_CPPFLAGS = \
+	-I$(top_srcdir)/src/api/ccapi \
+	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/sslutils \
+	$(NO_GLOBUS_FLAGS) \
+	$(EXPAT_CFLAGS) \
+	$(OPENSSL_CFLAGS)
+
 if BUILD_CLIENTS
 bin_PROGRAMS = voms-proxy-init
 
@@ -13,12 +21,6 @@ voms_proxy_init_LDADD = \
 	$(OPENSSL_LIBS) \
   $(top_builddir)/src/common/libutilc_nog.la \
 	$(EXPAT_LIBS)
-
-AM_CPPFLAGS = -I$(top_srcdir)/src/api/ccapi \
-	-I$(top_srcdir)/src/include \
-	-I$(top_srcdir)/src/sslutils \
-	$(NO_GLOBUS_FLAGS) \
-	$(EXPAT_CFLAGS)
 
 install-exec-hook:
 	-ln -s voms-proxy-init $(DESTDIR)$(bindir)/voms-proxy-list

--- a/src/client/vomsclient.cc
+++ b/src/client/vomsclient.cc
@@ -53,6 +53,7 @@ extern "C" {
 #include <sstream>
 #include <algorithm>
 #include <string>
+#include <random>
 
 #include "options.h"
 #include "vomsxml.h"
@@ -137,24 +138,6 @@ static void kpcallback(int p, UNUSED(int n), UNUSED(void* v))
 extern int proxy_verify_cert_chain(X509 * ucert, STACK_OF(X509) * cert_chain, proxy_verify_desc * pvd);
 extern void proxy_verify_ctx_init(proxy_verify_ctx_desc * pvxd);
 }
-
-
-class rand_wrapper 
-{
-
-public:
-  
-  rand_wrapper(unsigned int seed)
-  {
-    srand(seed);
-  }
-
-  UNUSED(ptrdiff_t operator() (ptrdiff_t max))
-  {
-    return static_cast<ptrdiff_t>(rand() % max);
-  }
-
-};
 
 Client::Client(int argc, char ** argv) :
                                          ignorewarn(false),
@@ -649,10 +632,8 @@ int Client::Run()
     /* find servers for that vo */
     std::vector<contactdata> servers;
     servers = v->FindByAlias(contact.nick());
-    rand_wrapper rd(time(0));
-    random_shuffle(servers.begin(), 
-                   servers.end(),
-                   rd);
+    std::default_random_engine rd{std::random_device{}()};
+    std::shuffle(servers.begin(), servers.end(), rd);
 
     std::string vo = (contact.vo().empty() ? servers[0].vo : contact.vo());
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,14 @@
 
+AM_CPPFLAGS = \
+	-I $(top_srcdir)/src/include \
+	-I $(top_srcdir)/src/sslutils \
+	$(EXPAT_CFLAGS) \
+	$(OPENSSL_CFLAGS)
+
+AM_LDFLAGS = \
+	$(EXPAT_LIBS) \
+	$(OPENSSL_LIBS)
+
 noinst_LTLIBRARIES = \
 	libutilities_nog.la \
 	libutilc_nog.la
@@ -12,23 +22,11 @@ libutilities_nog_la_SOURCES = \
 
 libutilities_nog_la_CFLAGS = \
 	-DNOGLOBUS \
+	$(NO_GLOBUS_FLAGS)
+
+libutilc_nog_la_CFLAGS = \
 	$(NO_GLOBUS_FLAGS) \
-	-I $(top_srcdir)/src/include
-
-AM_CPPFLAGS = \
-	-I $(top_srcdir)/src/include \
-	-I $(top_srcdir)/src/sslutils \
-	$(EXPAT_CFLAGS)
-
-AM_LDFLAGS = \
-	$(EXPAT_LIBS)
-
-libutilc_nog_la_CPPFLAGS = \
-	$(NO_GLOBUS_FLAGS) \
-	-DNOGLOBUS \
-	-I $(top_srcdir)/src/include \
-	-I $(top_srcdir)/src/sslutils \
-	$(EXPAT_CFLAGS) 
+	-DNOGLOBUS
 
 libutilc_nog_la_SOURCES = \
 	list.c \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -40,13 +40,15 @@ voms_LDADD = \
 	$(GSOAP_SSL_PP_LIBS) \
 	$(OPENSSL_LIBS) \
 	$(EXPAT_LIBS) \
-	-ldl 
+	-ldl
 
-voms_CFLAGS = $(GSOAP_SSL_PP_CFLAGS) -DHAVE_OPENSSL_SSL_H
-
-AM_CPPFLAGS = \
+voms_CPPFLAGS = \
+	$(GSOAP_PP_CFLAGS) \
+	-DHAVE_OPENSSL_SSL_H \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/api/ccapi \
-	$(NO_GLOBUS_FLAGS)
+	$(NO_GLOBUS_FLAGS) \
+	$(OPENSSL_CFLAGS)
+
 
 endif

--- a/src/server/vomsd.cc
+++ b/src/server/vomsd.cc
@@ -1137,9 +1137,9 @@ bool VOMSServer::makeAC(vomsresult& vr, EVP_PKEY *key, X509 *issuer,
     if (!existing.empty())
     {
       LOGM(VARP, logh, LEV_DEBUG, T_PRE,  "User comes with valid fqans for this VO. Computing fqans intersection.");
-      if (fqans.erase(remove_if(fqans.begin(),
-                                fqans.end(),
-                                bind2nd(std::ptr_fun(not_in), existing)),
+      if (fqans.erase(std::remove_if(fqans.begin(),
+                                     fqans.end(),
+                                     [&](std::string const& s) { return not_in(s, existing); }),
                       fqans.end()) != fend)
       {
         LOGM(VARP, logh, LEV_DEBUG, T_PRE,  "Only a subset of the requested attributes will be returned.");
@@ -1151,8 +1151,8 @@ bool VOMSServer::makeAC(vomsresult& vr, EVP_PKEY *key, X509 *issuer,
     {
       
       LOGM(VARP, logh, LEV_DEBUG, T_PRE,  "Dropping generic attributes for fqans which cannot be issued for current request.");
-      attribs.erase(remove_if(attribs.begin(), attribs.end(),
-                              bind2nd(std::ptr_fun(checkinside), fqans)),
+      attribs.erase(std::remove_if(attribs.begin(), attribs.end(),
+                              [&](gattrib const& a) { return checkinside(a, fqans); }),
                     attribs.end());
     }
 

--- a/src/socklib/Makefile.am
+++ b/src/socklib/Makefile.am
@@ -14,7 +14,8 @@ libsock_nog_la_SOURCES = Client.cpp Server.cpp ipv6sock.cc io.cc
 libsock_nog_la_CXXFLAGS = \
 	$(NO_GLOBUS_FLAGS) \
 	-I $(top_srcdir)/src/include \
-	-I $(top_srcdir)/src/sslutils
+	-I $(top_srcdir)/src/sslutils \
+	$(OPENSSL_CFLAGS)
 
 libsock_nog_la_LIBADD = \
 	-lcrypto -lssl

--- a/src/socklib/ipv6sock.cc
+++ b/src/socklib/ipv6sock.cc
@@ -29,6 +29,13 @@
 #  define _POSIX_SOURCE 1
 #endif
 
+#ifndef NI_MAXHOST
+#  define NI_MAXHOST 1025
+#endif
+#ifndef NI_MAXSERV
+#  define NI_MAXSERV 32
+#endif
+
 #include <sys/types.h>
 #include <netdb.h>
 #include <sys/socket.h>

--- a/src/sslutils/Makefile.am
+++ b/src/sslutils/Makefile.am
@@ -45,10 +45,12 @@ endif
 libssl_utils_nog_la_SOURCES= $(SOURCES)
 
 libssl_utils_la_CFLAGS = \
-	-I $(top_srcdir)/src/include
+	-I $(top_srcdir)/src/include \
+	$(OPENSSL_CFLAGS)
 
 libssl_utils_nog_la_CFLAGS = \
 	$(NO_GLOBUS_FLAGS) \
-	-I $(top_srcdir)/src/include
+	-I $(top_srcdir)/src/include \
+	$(OPENSSL_CFLAGS)
 
 ###

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -5,6 +5,12 @@ bin_PROGRAMS = \
 	voms-proxy-fake \
 	voms-verify
 
+AM_CPPFLAGS = \
+	-I$(top_srcdir)/src/api/ccapi \
+	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/sslutils \
+	$(NO_GLOBUS_FLAGS) \
+	$(OPENSSL_CFLAGS)
 
 voms_proxy_info_SOURCES = \
 	voms_proxy_info.cc
@@ -61,11 +67,5 @@ voms_proxy_fake_LDADD = \
 	$(top_builddir)/src/replib/librep.la \
 	$(top_builddir)/src/sslutils/libssl_utils_nog.la \
 	$(OPENSSL_LIBS)
-
-AM_CPPFLAGS = \
-	-I$(top_srcdir)/src/api/ccapi \
-	-I$(top_srcdir)/src/include \
-	-I$(top_srcdir)/src/sslutils \
-	$(NO_GLOBUS_FLAGS)
 
 endif


### PR DESCRIPTION
In particular voms now should build when dependencies such as openssl, expat and gsoap come with brew. This setup is somewhat similar to when the build is on macOS and is instrumental to fix #137.

Closes #137 