### PR TITLE
Fix compilation with GCC 15 (Fedora 42)

### DIFF
--- a/src/ac/newformat.c
+++ b/src/ac/newformat.c
@@ -197,5 +197,5 @@ EVP_PKEY *EVP_PKEY_dup(EVP_PKEY *pkey)
 
 int AC_verify(X509_ALGOR *algor1, ASN1_BIT_STRING *signature,char *data, EVP_PKEY *pkey)
 {
-  return ASN1_verify((int (*)())i2d_AC_INFO, algor1, signature, data, pkey);
+  return ASN1_verify((i2d_of_void *)i2d_AC_INFO, algor1, signature, data, pkey);
 }

--- a/src/ac/write.c
+++ b/src/ac/write.c
@@ -482,7 +482,7 @@ int writeac(X509 *issuerc, STACK_OF(X509) *issuerstack, X509 *holder, EVP_PKEY *
     md = EVP_sha1();
   }
 
-  ASN1_sign((int (*)())i2d_AC_INFO, a->acinfo->alg, a->sig_alg, a->signature,
+  ASN1_sign((i2d_of_void *)i2d_AC_INFO, a->acinfo->alg, a->sig_alg, a->signature,
 	    (char *)a->acinfo, pkey, md);
 
   *ac = a;

--- a/src/client/vomsclient.cc
+++ b/src/client/vomsclient.cc
@@ -100,10 +100,10 @@ bool dontverifyac = false;
 
 extern "C" {
   
-static int (*pw_cb)() = NULL;
+static pem_password_cb *pw_cb = NULL;
 
 
-static int pwstdin_callback(char * buf, int num, UNUSED(int w)) 
+static int pwstdin_callback(char * buf, int num, UNUSED(int w), UNUSED(void *u))
 {
   int i;
   
@@ -472,7 +472,7 @@ Client::Client(int argc, char ** argv) :
   /* allow password from stdin */
   
   if (pwstdin)
-    pw_cb = (int (*)())(pwstdin_callback);
+    pw_cb = pwstdin_callback;
 
 
   /* file used */

--- a/src/include/sslutils.h
+++ b/src/include/sslutils.h
@@ -354,7 +354,7 @@ int proxy_load_user_cert_and_key_pkcs12(const char *user_cert,
                                         X509 **cert,
                                         STACK_OF(X509) **stack,
                                         EVP_PKEY **pkey,
-                                        int (*pw_cb) ());
+                                        pem_password_cb *pw_cb);
 
 int
 proxy_get_filenames(
@@ -369,7 +369,7 @@ int
 proxy_load_user_cert(
     const char *                        user_cert,
     X509 **                             certificate,
-    int                                 (*pw_cb)(),
+    pem_password_cb *                   pw_cb,
     unsigned long *                     hSession);
 
 int
@@ -377,7 +377,7 @@ proxy_load_user_key(
     EVP_PKEY **                         private_key,
     X509 * ucert,
     const char *                        user_key,
-    int                                 (*pw_cb)(),
+    pem_password_cb *                   pw_cb,
     unsigned long *                     hSession);
 
 void
@@ -514,7 +514,7 @@ int PRIVATE determine_filenames(char **cacert, char **certdir, char **outfile,
                                 char **certfile, char **keyfile, int noregen);
 int load_credentials(const char *certname, const char *keyname,
                              X509 **cert, STACK_OF(X509) **stack, EVP_PKEY **key,
-                             int (*callback)());
+                             pem_password_cb *callback);
 int PRIVATE load_certificate_from_file(FILE *file, X509 **cert, 
                                        STACK_OF(X509) **stack);
 

--- a/src/server/vomsd-rest.cc
+++ b/src/server/vomsd-rest.cc
@@ -44,18 +44,18 @@ extern "C" {
 #include "fqan.h"
 #include "data.h"
 
-static int (*pw_cb)() = NULL;
+static pem_password_cb *pw_cb = NULL;
 static bool makeACSSL(vomsresult &vr, SSL *ssl, const std::string& command, const std::string &orderstring, const std::string& targets, int requested, VOMSServer *v);
 static int makeACREST(struct soap *soap, const std::string& command, const std::string& orderstring, const std::string& targets, int requested, int unknown);
 int http_get(soap *soap);
-static int pwstdin_callback(char * buf, int num, UNUSED(int w));
+static int pwstdin_callback(char * buf, int num, UNUSED(int w), UNUSED(void *u));
 static bool get_parameter(char **path, char **name, char **value);
 
 extern VOMSServer *selfpointer;
 extern void *logh;
 extern char *maingroup;
 
-static int pwstdin_callback(char * buf, int num, UNUSED(int w)) 
+static int pwstdin_callback(char * buf, int num, UNUSED(int w), UNUSED(void *u))
 {
   int i;
   
@@ -82,7 +82,7 @@ makeACSSL(vomsresult &vr, SSL *ssl, const std::string& command, const std::strin
   X509 *realholder = get_real_cert(holder, chain);
   X509 *issuer = NULL;
   EVP_PKEY *key = NULL;
-  pw_cb =(int (*)())(pwstdin_callback);
+  pw_cb = pwstdin_callback;
   char *hostcert = (char*)"/etc/grid-security/hostcert.pem";
   char *hostkey  = (char*)"/etc/grid-security/hostkey.pem";
 

--- a/src/sslutils/sslutils.c
+++ b/src/sslutils/sslutils.c
@@ -2782,7 +2782,7 @@ Parameters:
 Returns:
 **********************************************************************/
 
-static int cert_load_pkcs12(BIO *bio, int (*pw_cb)(), X509 **cert, EVP_PKEY **key, STACK_OF(X509) **chain)
+static int cert_load_pkcs12(BIO *bio, pem_password_cb *pw_cb, X509 **cert, EVP_PKEY **key, STACK_OF(X509) **chain)
 {
   PKCS12 *p12 = NULL;
   char *password = NULL;
@@ -2798,7 +2798,7 @@ static int cert_load_pkcs12(BIO *bio, int (*pw_cb)(), X509 **cert, EVP_PKEY **ke
     int sz = 0;
 
     if (pw_cb)
-      sz = pw_cb(buffer, 1024, 0);
+      sz = pw_cb(buffer, 1024, 0, NULL);
     else
       if (EVP_read_pw_string(buffer, 1024, EVP_get_pw_prompt(), 0) != -1)
         sz = strlen(buffer);
@@ -2826,7 +2826,7 @@ int PRIVATE proxy_load_user_cert_and_key_pkcs12(const char *user_cert,
                                                 X509 **cert,
                                                 STACK_OF(X509) **stack,
                                                 EVP_PKEY **pkey,
-                                                int (*pw_cb) ())
+                                                pem_password_cb *pw_cb)
 {
   BIO *bio = BIO_new_file(user_cert, "rb");
   int res = cert_load_pkcs12(bio, pw_cb, cert, pkey, stack);
@@ -2852,9 +2852,9 @@ int PRIVATE proxy_load_user_cert_and_key_pkcs12(const char *user_cert,
 int PRIVATE
 proxy_load_user_cert(
     const char *                        user_cert,
-    X509 **                              certificate,
-    UNUSED(int                                 (*pw_cb)()),
-    UNUSED(unsigned long *                     hSession))
+    X509 **                             certificate,
+    UNUSED(pem_password_cb *            pw_cb),
+    UNUSED(unsigned long *              hSession))
 {
     int                                 status = -1;
     FILE *                              fp;
@@ -2985,13 +2985,13 @@ proxy_load_user_key(
     EVP_PKEY **                         private_key,
     X509 *                              ucert,
     const char *                        user_key,
-    int                                 (*pw_cb)(),
-    UNUSED(unsigned long *                     hSession))
+    pem_password_cb *                   pw_cb,
+    UNUSED(unsigned long *              hSession))
 {
     int                                 status = -1;
     FILE *                              fp;
     EVP_PKEY *                          ucertpkey;
-    int                                 (*xpw_cb)();
+    pem_password_cb *                   xpw_cb;
 
     if (!private_key)
       return 0;
@@ -3467,7 +3467,7 @@ err:
 
 int load_credentials(const char *certname, const char *keyname,
                      X509 **cert, STACK_OF(X509) **stack, EVP_PKEY **key,
-                     int (*callback)())
+                     pem_password_cb *callback)
 {
   STACK_OF(X509) *chain = NULL;
 

--- a/src/utils/vomsfake.cc
+++ b/src/utils/vomsfake.cc
@@ -109,9 +109,9 @@ bool quiet = false;
 
 extern "C" {
   
-static int (*pw_cb)() = NULL;
+static pem_password_cb *pw_cb = NULL;
 
-static int pwstdin_callback(char * buf, int num, UNUSED(int w)) 
+static int pwstdin_callback(char * buf, int num, UNUSED(int w), UNUSED(void *u))
 {
   int i;
   
@@ -431,7 +431,7 @@ Fake::Fake(int argc, char ** argv) :   confile(conf_file_name),
   /* allow password from stdin */
 
   if(pwstdin)
-    pw_cb = (int (*)())(pwstdin_callback);
+    pw_cb = pwstdin_callback;
 
   /* with --debug prints configuration files used */
 


### PR DESCRIPTION
GCC 15 has improved diagnostics and detects more incompatible pointer type errors than earlier versions. Especially function pointers being assigned pointers to function with the wrong type and/or number of arguments are better detected.

This commit fixes the compilation with GCC 15 on Fedora 42.