### PR TITLE
Fix compilation with openssl 4.0.0

### DIFF
--- a/src/ac/extensions.c
+++ b/src/ac/extensions.c
@@ -107,7 +107,6 @@ void *targets_s2i(UNUSED(struct v3_ext_method *method), UNUSED(struct v3_ext_ctx
   char *back = list;
   AC_TARGETS *a = AC_TARGETS_new();
 
-  int attlist;
   do {
     pos = strchr(list, ',');
 
@@ -129,7 +128,6 @@ void *targets_s2i(UNUSED(struct v3_ext_method *method), UNUSED(struct v3_ext_ctx
       g->d.ia5 = tmpr;
       targ->name = g;
       sk_AC_TARGET_push(a->targets, targ);
-      attlist++;
     }
     if (pos)
       list = ++pos;
@@ -210,7 +208,7 @@ void *authkey_s2i(UNUSED(struct v3_ext_method *method), UNUSED(struct v3_ext_ctx
   AUTHORITY_KEYID *keyid = AUTHORITY_KEYID_new();
 
   if (str && keyid) {
-    X509_PUBKEY* pk = X509_get_X509_PUBKEY(cert);
+    const X509_PUBKEY* pk = X509_get_X509_PUBKEY(cert);
     assert(pk != NULL && "X509_get_X509_PUBKEY failed");
     unsigned char const* data;
     int len;

--- a/src/ac/validate.cc
+++ b/src/ac/validate.cc
@@ -205,9 +205,10 @@ int validate(X509 *cert, X509 *issuer, AC *ac, voms &v, verify_type valids, time
   }
 
   v.version    = 1;
-  v.siglen     = ac->signature->length;
-  v.signature  = std::string((char*)ac->signature->data, ac->signature->length);
-  bn               = ASN1_INTEGER_to_BN(ac->acinfo->serial, NULL);
+  v.siglen     = ASN1_STRING_length(ac->signature);
+  v.signature  = std::string((const char*) ASN1_STRING_get0_data(ac->signature),
+                             ASN1_STRING_length(ac->signature));
+  bn           = ASN1_INTEGER_to_BN(ac->acinfo->serial, NULL);
   char *bnstring = BN_bn2hex(bn);
   v.serial     = std::string(bnstring);
   OPENSSL_free(bnstring);
@@ -294,15 +295,17 @@ int validate(X509 *cert, X509 *issuer, AC *ac, voms &v, verify_type valids, time
       if (X509_NAME_cmp(name->d.dirn, X509_get_subject_name(issuer)))
         ERROR(AC_ERR_ISSUER_NAME);
 
-    if (ac->acinfo->serial->length>20)
+    if (ASN1_STRING_length(ac->acinfo->serial) > 20)
       ERROR(AC_ERR_SERIAL);
   }
 
   b = ac->acinfo->validity->notBefore;
   a = ac->acinfo->validity->notAfter;
 
-  v.date1 = std::string((char*)b->data, b->length);
-  v.date2 = std::string((char*)a->data, a->length);
+  v.date1 = std::string((const char*) ASN1_STRING_get0_data(b),
+                        ASN1_STRING_length(b));
+  v.date2 = std::string((const char*) ASN1_STRING_get0_data(a),
+                        ASN1_STRING_length(a));
 
   if (valids & VERIFY_DATE) {
     time_t ctime, dtime;
@@ -315,8 +318,8 @@ int validate(X509 *cert, X509 *issuer, AC *ac, voms &v, verify_type valids, time
     ctime += 300;
     dtime = ctime-600;
 
-    if ((a->type != V_ASN1_GENERALIZEDTIME) ||
-        (b->type != V_ASN1_GENERALIZEDTIME))
+    if ((ASN1_STRING_type(a) != V_ASN1_GENERALIZEDTIME) ||
+        (ASN1_STRING_type(b) != V_ASN1_GENERALIZEDTIME))
       ERROR(AC_ERR_DATES);
 
     if (((X509_cmp_time(b, &vertime) >= 0) &&
@@ -379,7 +382,8 @@ static int checkAttributes(STACK_OF(AC_ATTR) *atts, voms &v)
   /* put policyAuthority in voms struct */
   data = sk_GENERAL_NAME_value(capattr->names, 0);
   if (data->type == GEN_URI) {
-    v.voname = std::string((char*)data->d.ia5->data, data->d.ia5->length);
+    v.voname = std::string((const char*) ASN1_STRING_get0_data(data->d.ia5),
+                           ASN1_STRING_length(data->d.ia5));
     std::string::size_type point = v.voname.find("://");
 
     if (point != std::string::npos) {
@@ -398,10 +402,11 @@ static int checkAttributes(STACK_OF(AC_ATTR) *atts, voms &v)
   for (int i=0; i<sk_AC_IETFATTRVAL_num(values); i++) {
     capname = sk_AC_IETFATTRVAL_value(values, i);
 
-    if (!(capname->type == V_ASN1_OCTET_STRING))
+    if (!(ASN1_STRING_type(capname) == V_ASN1_OCTET_STRING))
       return AC_ERR_ATTRIB_FQAN;
 
-    std::string str  = std::string((char*)capname->data, capname->length);
+    std::string str = std::string((const char*) ASN1_STRING_get0_data(capname),
+                                  ASN1_STRING_length(capname));
     std::string::size_type top_group_size = top_group.size();
     std::string::size_type str_size = str.size();
 
@@ -556,14 +561,13 @@ static int checkExtensions(STACK_OF(X509_EXTENSION) *exts, X509 *iss, int valids
           if (key->keyid) {
             unsigned char hashed[SHA_DIGEST_LENGTH];
 
-            ASN1_BIT_STRING* pubkey = X509_get0_pubkey_bitstr(iss);
-            if (!SHA1(pubkey->data,
-                      pubkey->length,
-                      hashed))
+            const ASN1_BIT_STRING* pubkey = X509_get0_pubkey_bitstr(iss);
+            if (!SHA1(ASN1_STRING_get0_data(pubkey),
+                      ASN1_STRING_length(pubkey), hashed))
               ret = AC_ERR_EXT_KEY;
-          
-            if ((memcmp(key->keyid->data, hashed, 20) != 0) && 
-                (key->keyid->length == 20))
+
+            if ((memcmp(ASN1_STRING_get0_data(key->keyid), hashed, 20) != 0) &&
+                (ASN1_STRING_length(key->keyid) == 20))
               ret = AC_ERR_EXT_KEY;
           }
           else {
@@ -573,8 +577,8 @@ static int checkExtensions(STACK_OF(X509_EXTENSION) *exts, X509 *iss, int valids
             if (ASN1_INTEGER_cmp((key->serial),
                                 (X509_get0_serialNumber(iss))))
               ret = AC_ERR_EXT_KEY;
-	  
-            if (key->serial->type != GEN_DIRNAME)
+
+            if (ASN1_STRING_type(key->serial) != GEN_DIRNAME)
               ret = AC_ERR_EXT_KEY;
 
             if (X509_NAME_cmp(sk_GENERAL_NAME_value((key->issuer), 0)->d.dirn, 
@@ -632,15 +636,19 @@ static int interpret_attributes(AC_FULL_ATTRIBUTES *full_attr, realdata *rd)
       AC_ATTRIBUTE *at = sk_AC_ATTRIBUTE_value(atts, j);
 
       struct attribute a;
-      a.name      = std::string((char*)at->name->data,      at->name->length);
-      a.value     = std::string((char*)at->value->data,     at->value->length);
-      a.qualifier = std::string((char*)at->qualifier->data, at->qualifier->length);
+      a.name      = std::string((const char*) ASN1_STRING_get0_data(at->name),
+                                ASN1_STRING_length(at->name));
+      a.value     = std::string((const char*) ASN1_STRING_get0_data(at->value),
+                                ASN1_STRING_length(at->value));
+      a.qualifier = std::string((const char*) ASN1_STRING_get0_data(at->qualifier),
+                                ASN1_STRING_length(at->qualifier));
 
       al.attributes.push_back(a);
     }
 
     gn = sk_GENERAL_NAME_value(holder->grantor, 0);
-    al.grantor = std::string((char*)gn->d.ia5->data, gn->d.ia5->length);
+    al.grantor = std::string((const char*) ASN1_STRING_get0_data(gn->d.ia5),
+                             ASN1_STRING_length(gn->d.ia5));
 
     rd->attributes->push_back(al);
   }

--- a/src/ac/write.c
+++ b/src/ac/write.c
@@ -200,7 +200,8 @@ int writeac(X509 *issuerc, STACK_OF(X509) *issuerstack, X509 *holder, EVP_PKEY *
             STACK_OF(X509_EXTENSION) *extensions)
 {
   AC *a;
-  X509_NAME *name1, *name2, *subjdup, *issdup;
+  const X509_NAME *name1, *name2;
+  X509_NAME *subjdup, *issdup;
   GENERAL_NAME *dirn, *dirn2;
   ASN1_INTEGER  *serial, *holdserial, *version;
   ASN1_BIT_STRING *uid;

--- a/src/api/ccapi/api_util.cc
+++ b/src/api/ccapi/api_util.cc
@@ -76,6 +76,12 @@ extern "C" {
 #endif
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+#define CONST4 const
+#else
+#define CONST4
+#endif
+
 extern proxy_verify_desc *setup_initializers(char *cadir);
 extern void destroy_initializers(void *data);
 static bool dncompare(const char *mut, const char *fixed);
@@ -133,7 +139,7 @@ vomsdata::evaluate(AC_SEQ *acs, const std::string& subject,
 }
 
 
-static X509_EXTENSION *get_ext(X509 *cert, const char *name)
+static CONST4 X509_EXTENSION *get_ext(X509 *cert, const char *name)
 {
   int nid   = OBJ_txt2nid(name);
   int index = X509_get_ext_by_NID(cert, nid, -1);
@@ -146,7 +152,7 @@ static X509_EXTENSION *get_ext(X509 *cert, const char *name)
 
 static bool findexts(X509 *cert , AC_SEQ **listnew, std::string &extra_data, std::string &workvo)
 {
-  X509_EXTENSION *ext;
+  CONST4 X509_EXTENSION *ext;
   bool found = false;
 
   ext = get_ext(cert, "acseq");
@@ -157,17 +163,19 @@ static bool findexts(X509 *cert , AC_SEQ **listnew, std::string &extra_data, std
 
   ext = get_ext(cert, "incfile");
   if (ext) {
-    ASN1_OCTET_STRING* value = X509_EXTENSION_get_data(ext);
+    const ASN1_OCTET_STRING* value = X509_EXTENSION_get_data(ext);
     assert(value && "X509_EXTENSION_get_data failed");
-    extra_data = std::string(reinterpret_cast<char*>(value->data), value->length);
+    extra_data = std::string((const char*) ASN1_STRING_get0_data(value),
+                             ASN1_STRING_length(value));
     found = true;
   }
 
   ext = get_ext(cert, "vo");
   if (ext) {
-    ASN1_OCTET_STRING* value = X509_EXTENSION_get_data(ext);
+    const ASN1_OCTET_STRING* value = X509_EXTENSION_get_data(ext);
     assert(value && "X509_EXTENSION_get_data failed");
-    workvo = std::string(reinterpret_cast<char*>(value->data), value->length);
+    workvo = std::string((const char*) ASN1_STRING_get0_data(value),
+                         ASN1_STRING_length(value));
   }
 
   return found;
@@ -423,7 +431,8 @@ vomsdata::check(void *data)
     return NULL;
   }
   
-  std::string voname((const char *)name->d.ia5->data, 0, name->d.ia5->length);
+  std::string voname((const char*) ASN1_STRING_get0_data(name->d.ia5), 0,
+                     ASN1_STRING_length(name->d.ia5));
   std::string::size_type cpos = voname.find("://");
   std::string hostname;
 
@@ -760,7 +769,7 @@ vomsdata::check_cert(STACK_OF(X509) *stack)
         error = VERR_VERIFY;
         if (X509_STORE_CTX_init(csc, ctx, sk_X509_value(stack, 0), NULL)==0) {
           error = VERR_MEM;
-        } else	{
+        } else {
 
           X509_STORE_CTX_set_ex_data(csc, PVD_STORE_EX_DATA_IDX, pvd);
           /* X509_STORE_CTX_get0_param() only returns NULL if
@@ -813,7 +822,7 @@ vomsdata::check_cert(STACK_OF(X509) *stack)
 
 bool
 vomsdata::contact(const std::string &hostname, int port, UNUSED(const std::string &contact),
-	const std::string &command, std::string &buf, std::string &u, std::string &uc,
+                  const std::string &command, std::string &buf, std::string &u, std::string &uc,
                   int timeout)
 {
   GSISocketClient sock(hostname, port);

--- a/src/api/ccapi/voms_api.cc
+++ b/src/api/ccapi/voms_api.cc
@@ -545,8 +545,6 @@ bool vomsdata::Retrieve(X509_EXTENSION *ext)
 
 bool vomsdata::Retrieve(AC *ac)
 {
-  verify_type v = ver_type;
-
   ver_type = (verify_type)((int) ver_type & (~VERIFY_ID));
 
   voms vv;
@@ -786,7 +784,6 @@ bool vomsdata::loadfile0(std::string filename, UNUSED(uid_t uid), UNUSED(gid_t g
   }
 
   /* Load the file */
-  int linenum = 1;
   bool ok = true;
   bool verok = true;
 
@@ -818,7 +815,6 @@ bool vomsdata::loadfile0(std::string filename, UNUSED(uid_t uid), UNUSED(gid_t g
         return false;
       }
     }
-    linenum++;
   }
   return true;
 }
@@ -1025,8 +1021,8 @@ std::vector<std::string> voms::GetTargets()
         AC_TARGET *name = NULL;
         name = sk_AC_TARGET_value(target->targets, i);
         if (name->name->type == GEN_URI)
-          targets.push_back(std::string((char*)(name->name->d.ia5->data), 
-                                        name->name->d.ia5->length));
+          targets.push_back(std::string((const char*) ASN1_STRING_get0_data(name->name->d.ia5),
+                                        ASN1_STRING_length(name->name->d.ia5)));
       }
     }
     AC_TARGETS_free(target);

--- a/src/client/vomsclient.cc
+++ b/src/client/vomsclient.cc
@@ -123,21 +123,7 @@ static int pwstdin_callback(char * buf, int num, UNUSED(int w), UNUSED(void *u))
   }
   return i;	
 }
-  
-static void kpcallback(int p, UNUSED(int n), UNUSED(void* v))
-{
-  char c='B';
-    
-  if (quiet) return;
-    
-  if (p == 0) c='.';
-  if (p == 1) c='+';
-  if (p == 2) c='*';
-  if (p == 3) c='\n';
-  if (!debug) c = '.';
-  fputc(c,stderr);
-}
-  
+
 extern int proxy_verify_cert_chain(X509 * ucert, STACK_OF(X509) * cert_chain, proxy_verify_desc * pvd);
 extern void proxy_verify_ctx_init(proxy_verify_ctx_desc * pvxd);
 }
@@ -1142,8 +1128,6 @@ static bool check_validity_dates(X509 const* cert, int& time_left, std::string& 
 
 bool Client::pcdInit() 
 {
-  int status = false;
-
   ERR_load_prxyerr_strings(0);
   SSLeay_add_ssl_algorithms();
   ERR_load_crypto_strings();

--- a/src/include/sslutils.h
+++ b/src/include/sslutils.h
@@ -400,11 +400,19 @@ int
 proxy_check_proxy_name(
     X509 *);
 
-int 
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
+int
 proxy_check_issued(
     X509_STORE_CTX *                    ctx,
     X509 *                              x,
     X509 *                              issuer);
+#else
+int
+proxy_check_issued(
+    X509_STORE_CTX *                    ctx,
+    const X509 *                        x,
+    const X509 *                        issuer);
+#endif
 
 int
 proxy_verify_certchain(

--- a/src/socklib/Server.cpp
+++ b/src/socklib/Server.cpp
@@ -368,7 +368,6 @@ GSISocketServer::AcceptGSIAuthentication()
   bool accept_timed_out = false;
   int expected = 0;
   BIO *bio = NULL;
-  BIO_METHOD* bio_method = NULL;
   char *cert_file, *user_cert, *user_key, *user_proxy;
   char *serial=NULL;
 

--- a/src/sslutils/proxy.c
+++ b/src/sslutils/proxy.c
@@ -543,8 +543,8 @@ struct VOMSProxy *VOMS_MakeProxy(struct VOMSProxyArguments *args, int *warning, 
       oct = ASN1_OCTET_STRING_new();
       assert(oct != NULL && "ASN1_OCTET_STRING_new failed");
 
-      oct->data = der;
-      oct->length = len;
+      ASN1_OCTET_STRING_set(oct, der, len);
+      OPENSSL_free(der);
       ex7 = X509_EXTENSION_create_by_NID(NULL, v3nid, 1 /*critical*/, oct);
 
       ASN1_OCTET_STRING_free(oct);
@@ -682,10 +682,9 @@ X509_EXTENSION *CreateProxyExtension(char * name, char *data, int datalen, int c
     PRXYerr(PRXYERR_F_PROXY_SIGN,PRXYERR_R_CLASS_ADD_EXT);
     goto err;
   }
-  
-  ex_oct->data   = (unsigned char*)data;
-  ex_oct->length = datalen;
-  
+
+  ASN1_OCTET_STRING_set(ex_oct, (const unsigned char*) data, datalen);
+
   if (!(ex = X509_EXTENSION_create_by_OBJ(NULL, ex_obj, crit, ex_oct))) {
     PRXYerr(PRXYERR_F_PROXY_SIGN,PRXYERR_R_CLASS_ADD_EXT);
   }
@@ -693,9 +692,6 @@ X509_EXTENSION *CreateProxyExtension(char * name, char *data, int datalen, int c
  err:
   
   if (ex_oct) {
-    /* avoid spurious free of the contents. */
-    ex_oct->length = 0;
-    ex_oct->data = NULL;
     ASN1_OCTET_STRING_free(ex_oct);
   }
 
@@ -806,10 +802,10 @@ static int get_KeyUsageFlags(X509 *cert)
   ASN1_BIT_STRING *usage = X509_get_ext_d2i(cert, NID_key_usage, NULL, NULL);
   
   if (usage) {
-    if (usage->length > 0)
-      keyusage = usage->data[0];
-    if (usage->length > 1)
-      keyusage |= usage->data[1] << 8;
+    if (ASN1_STRING_length(usage) > 0)
+      keyusage = ASN1_STRING_get0_data(usage)[0];
+    if (ASN1_STRING_length(usage) > 1)
+      keyusage |= ASN1_STRING_get0_data(usage)[1] << 8;
 
     ASN1_BIT_STRING_free(usage);
   }

--- a/src/sslutils/proxycertinfo.c
+++ b/src/sslutils/proxycertinfo.c
@@ -107,9 +107,10 @@ static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
     BIO_printf(out, "%*sPolicy Language: ", indent, "");
     i2a_ASN1_OBJECT(out, pci->proxyPolicy->policyLanguage);
     BIO_puts(out, "\n");
-    if (pci->proxyPolicy->policy && pci->proxyPolicy->policy->data)
+    if (pci->proxyPolicy->policy &&
+        ASN1_STRING_get0_data(pci->proxyPolicy->policy))
         BIO_printf(out, "%*sPolicy Text: %s\n", indent, "",
-                   pci->proxyPolicy->policy->data);
+                   ASN1_STRING_get0_data(pci->proxyPolicy->policy));
     return 1;
 }
 
@@ -138,15 +139,15 @@ ASN1_OBJECT * PROXY_POLICY_get_policy_language(
 
 unsigned char * PROXY_POLICY_get_policy(
     PROXY_POLICY *                       policy,
-    int *                               length)
+    int *                                length)
 {
-    if(policy->policy)
-    { 
-        (*length) = policy->policy->length;
-        if(*length > 0 && policy->policy->data)
+    if (policy->policy)
+    {
+        (*length) = ASN1_STRING_length(policy->policy);
+        if (*length > 0 && ASN1_STRING_get0_data(policy->policy))
         {
-            unsigned char *                 copy = malloc(*length);
-            memcpy(copy, policy->policy->data, *length);
+            unsigned char *copy = malloc(*length);
+            memcpy(copy, ASN1_STRING_get0_data(policy->policy), *length);
             return copy;
         }
     }
@@ -290,7 +291,7 @@ PROXY_CERT_INFO_EXTENSION_set_path_length(
 
     if (pl != -1) {
       if (pci->pcPathLengthConstraint == NULL) {
-	pci->pcPathLengthConstraint = ASN1_INTEGER_new();
+        pci->pcPathLengthConstraint = ASN1_INTEGER_new();
       }
       return ASN1_INTEGER_set(pci->pcPathLengthConstraint, pl);
     } else {

--- a/src/sslutils/sslutils.c
+++ b/src/sslutils/sslutils.c
@@ -255,13 +255,13 @@ Returns :
 ********************************************************************/
 static int
 X509_NAME_cmp_no_set(
-    X509_NAME *                         a,
-    X509_NAME *                         b)
+    const X509_NAME *                         a,
+    const X509_NAME *                         b)
 {
     int                                 i;
     int                                 j;
-    X509_NAME_ENTRY *                   na;
-    X509_NAME_ENTRY *                   nb;
+    const X509_NAME_ENTRY *             na;
+    const X509_NAME_ENTRY *             nb;
 
     if (X509_NAME_entry_count(a) != X509_NAME_entry_count(b))
     {
@@ -272,8 +272,8 @@ X509_NAME_cmp_no_set(
     {
         na = X509_NAME_get_entry(a,i);
         nb = X509_NAME_get_entry(b,i);
-        ASN1_STRING* sa = X509_NAME_ENTRY_get_data(na);
-        ASN1_STRING* sb = X509_NAME_ENTRY_get_data(nb);
+        const ASN1_STRING* sa = X509_NAME_ENTRY_get_data(na);
+        const ASN1_STRING* sb = X509_NAME_ENTRY_get_data(nb);
         j = ASN1_STRING_length(sa) - ASN1_STRING_length(sb);
 
         if (j)
@@ -404,10 +404,12 @@ Returns:
 void PRIVATE
 ERR_set_continue_needed(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
     ERR_STATE *es;
     es = ERR_get_state();
     es->err_data_flags[es->top] =
         es->err_data_flags[es->top] | ERR_DISPLAY_CONTINUE_NEEDED;
+#endif
 }
 
 
@@ -994,8 +996,8 @@ proxy_sign(
         PRXYerr(PRXYERR_F_PROXY_SIGN,PRXYERR_R_PROCESS_SIGN);
         if (proxyver >= 3) {
           free(newcn);
-	  free((void*)newserial);
-	}
+          free((void*)newserial);
+        }
         return 1;
       }
     }
@@ -1379,7 +1381,7 @@ proxy_construct_name(
     if(newcn)
     {
         if ((name_entry = X509_NAME_ENTRY_create_by_NID(NULL,
-							NID_commonName,
+                                                        NID_commonName,
                                                         V_ASN1_APP_CHOOSE,
                                                         (unsigned char *)newcn,
                                                         len)) == NULL)
@@ -1667,10 +1669,17 @@ int proxy_verify_name(X509* cert){
 }
 
 
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
 int PRIVATE
 proxy_check_issued(UNUSED(X509_STORE_CTX *  ctx),
       X509 *                              x,
       X509 *                              issuer)
+#else
+int PRIVATE
+proxy_check_issued(UNUSED(X509_STORE_CTX *  ctx),
+      const X509 *                        x,
+      const X509 *                        issuer)
+#endif
 {
   int return_value;
   int return_code = 1;
@@ -3259,7 +3268,7 @@ time_t PRIVATE
 ASN1_UTCTIME_mktime(
     ASN1_UTCTIME *                      ctm)
 {
-  char     *str;
+  const char *str;
   time_t    offset;
   time_t    newtime;
   char      buff1[32];
@@ -3268,7 +3277,7 @@ ASN1_UTCTIME_mktime(
   struct tm tm;
   int       size = 0;
 
-  switch (ctm->type) {
+  switch (ASN1_STRING_type(ctm)) {
   case V_ASN1_UTCTIME:
     size=10;
     break;
@@ -3277,8 +3286,8 @@ ASN1_UTCTIME_mktime(
     break;
   }
   p = buff1;
-  i = ctm->length;
-  str = (char *)ctm->data;
+  i = ASN1_STRING_length(ctm);
+  str = (const char*) ASN1_STRING_get0_data(ctm);
   if ((i < 11) || (i > 17)) {
     return 0;
   }
@@ -3311,7 +3320,7 @@ ASN1_UTCTIME_mktime(
 
   tm.tm_isdst = 0;
   int index = 0;
-  if (ctm->type == V_ASN1_UTCTIME) {
+  if (ASN1_STRING_type(ctm) == V_ASN1_UTCTIME) {
     tm.tm_year  = (buff1[index++]-'0')*10;
     tm.tm_year += (buff1[index++]-'0');
   }
@@ -3765,7 +3774,7 @@ static X509_NAME *make_DN(const char *dnstring)
 static int check_critical_extensions(X509 *cert, int itsaproxy)
 {
   int i = 0;
-  ASN1_OBJECT *extension_obj;
+  const ASN1_OBJECT *extension_obj;
   int nid;
   X509_EXTENSION *ex;
 

--- a/src/sslutils/voms_cert_type.c
+++ b/src/sslutils/voms_cert_type.c
@@ -11,13 +11,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+#define CONST4 const
+#else
+#define CONST4
+#endif
+
 #define LIMITED_PROXY_OID               "1.3.6.1.4.1.3536.1.1.1.9"
 #define PROXYCERTINFO_OLD_OID           "1.3.6.1.4.1.3536.1.222"
 #define NULL_STR "<null>"
 
 
 static voms_result_t 
-voms_validation_error_with_detail(int code, X509_NAME* subject,
+voms_validation_error_with_detail(int code, const X509_NAME* subject,
     const char* detail) { 
 
   char sub_buf[256];
@@ -46,17 +52,17 @@ voms_validation_error_with_detail(int code, X509_NAME* subject,
 }
 
 static voms_result_t 
-voms_validation_error(int code, X509_NAME* subject){
+voms_validation_error(int code, const X509_NAME* subject){
 
   return voms_validation_error_with_detail(code, subject, NULL);
 
 }
 
 static
-X509_NAME_ENTRY* 
-get_last_cn_entry_from_subject(X509_NAME* subject){
+const X509_NAME_ENTRY*
+get_last_cn_entry_from_subject(const X509_NAME* subject){
 
-  X509_NAME_ENTRY* ne = NULL;
+  const X509_NAME_ENTRY* ne = NULL;
 
   if (subject == NULL){
     return NULL;
@@ -113,17 +119,17 @@ voms_get_cert_type(X509* cert, voms_cert_type_t* cert_type){
   voms_result_t result = VOMS_SUCCESS;
 
   BASIC_CONSTRAINTS* bc_ext = NULL;
-  X509_EXTENSION* ext = NULL;
+  CONST4 X509_EXTENSION* ext = NULL;
   PROXY_CERT_INFO_EXTENSION *pci_ext = NULL;
   PROXY_POLICY *policy = NULL;
   ASN1_OBJECT *policy_lang = NULL;
 
-  X509_NAME *subject = NULL;	
+  const X509_NAME *subject = NULL;
   X509_NAME *expected_subject = NULL;
-  X509_NAME_ENTRY *ne = NULL;
+  const X509_NAME_ENTRY *ne = NULL;
   X509_NAME_ENTRY *new_ne = NULL;
 
-  ASN1_STRING *ne_data = NULL;
+  const ASN1_STRING *ne_data = NULL;
 
   int critical;
   int index = -1;
@@ -256,11 +262,13 @@ voms_get_cert_type(X509* cert, voms_cert_type_t* cert_type){
 
     ne_data = X509_NAME_ENTRY_get_data(ne);
 
-    if (ne_data->length == 5 && !memcmp(ne_data->data,"proxy",5))
+    if (ASN1_STRING_length(ne_data) == 5 &&
+        !memcmp(ASN1_STRING_get0_data(ne_data), "proxy", 5))
     {
       *cert_type = VOMS_CERT_TYPE_GSI_2_PROXY;
     }
-    else if (ne_data->length == 13 && !memcmp(ne_data->data,"limited proxy",13))
+    else if (ASN1_STRING_length(ne_data) == 13 &&
+             !memcmp(ASN1_STRING_get0_data(ne_data), "limited proxy", 13))
     {
       *cert_type = VOMS_CERT_TYPE_GSI_2_LIMITED_PROXY;
     }
@@ -292,8 +300,9 @@ voms_get_cert_type(X509* cert, voms_cert_type_t* cert_type){
 
     ne_data = X509_NAME_ENTRY_get_data(ne);
 
-    if ((new_ne = X509_NAME_ENTRY_create_by_NID( NULL, NID_commonName,
-	    ne_data->type, ne_data->data, -1)) == NULL){
+    if ((new_ne = X509_NAME_ENTRY_create_by_NID(NULL, NID_commonName,
+          ASN1_STRING_type(ne_data),
+          ASN1_STRING_get0_data(ne_data), -1)) == NULL){
 
       result = voms_validation_error(
 	  PRXYERR_R_ERROR_BUILDING_SUBJECT,

--- a/src/utils/voms_proxy_info.cc
+++ b/src/utils/voms_proxy_info.cc
@@ -466,18 +466,8 @@ static STACK_OF(X509) *load_chain_from_file(char *certfile)
 static ASN1_TIME *
 convtime(std::string data)
 {
-  ASN1_TIME *t= ASN1_TIME_new();
-
-  t->data   = (unsigned char*)strdup(data.data());
-  t->length = data.size();
-  switch(t->length) {
-  case 10:
-    t->type = V_ASN1_UTCTIME;
-    break;
-  case 15:
-    t->type = V_ASN1_GENERALIZEDTIME;
-    break;
-  default:
+  ASN1_TIME *t = ASN1_TIME_new();
+  if (ASN1_TIME_set_string_X509(t, data.c_str()) == 0) {
     ASN1_TIME_free(t);
     return NULL;
   }
@@ -712,7 +702,7 @@ static bool print(X509 *cert, STACK_OF(X509) *chain, vomsdata &vd)
 
       if(res) {
         std::vector<voms>::const_iterator vend = vd.data.end();
-        for (std::vector<voms>::iterator v = vd.data.begin(); v != vd.data.end(); ++v) {
+        for (std::vector<voms>::iterator v = vd.data.begin(); v != vend; ++v) {
           if(v->voname == *i) {
             found = true;
             break;


### PR DESCRIPTION
Most changes are using ASN1_STRING_length(), ASN1_STRING_type() and ASN1_STRING_get0_data() instead of accessing the members of the ASN1_String struct directly.
There are some differences in const-ness.
I could not find any way to access ERR_STATE or modify it. The ERR_set_continue_needed() becomes a no-op.
Also fixes a few compiler warnings about unused variables.
Still compiles on RHEL+EPEL-8 with openssl 1.1.1k.